### PR TITLE
Add multi-environment settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,21 @@ alongside the rest of your dotfiles. By default the app creates
 
 ```json
 {
-  "repoDir": "/absolute/path/to/your/repo",
-  "workspaceRoot": "/absolute/path/to/worktrees"
+  "environments": {
+    "default": {
+      "repoDir": "/absolute/path/to/your/repo",
+      "workspaceRoot": "/absolute/path/to/worktrees"
+    }
+  },
+  "activeEnvironment": "default"
 }
 ```
 
-Edit this file to point at your repository and worktree directory before
-launching the app. Both paths are resolved to absolute paths automatically.
+Add additional environments to the `environments` object when you need to work
+with multiple repositories. The app exposes a dropdown in the header that lets
+you switch between the configured environments at runtime. The
+`activeEnvironment` key selects which environment is used when the app starts.
+All paths are resolved to absolute locations automatically.
 
 To use an alternative settings location (useful for scripting or tests), set
 the `WTM_SETTINGS_PATH` environment variable to your desired JSON file.

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -16,6 +16,11 @@ contextBridge.exposeInMainWorld("workspaceAPI", {
   refresh: (params) => invoke("workspace:refresh", params),
 });
 
+contextBridge.exposeInMainWorld("settingsAPI", {
+  listEnvironments: () => invoke("settings:listEnvironments"),
+  setActiveEnvironment: (params) => invoke("settings:setActiveEnvironment", params),
+});
+
 contextBridge.exposeInMainWorld("terminalAPI", {
   ensureSession: (params) => invoke("terminal:ensure", params),
   write: (sessionId, data) => ipcRenderer.send("terminal:write", { sessionId, data }),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,6 +15,10 @@
           <p>Manage git worktrees for your project repositories</p>
         </div>
         <div class="header-actions">
+          <label class="environment-switcher">
+            <span>Environment</span>
+            <select id="environment-select" name="environment"></select>
+          </label>
           <button id="refresh-button" class="accent-button" type="button">Refresh</button>
         </div>
       </header>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -93,6 +93,49 @@ code {
   gap: 8px;
 }
 
+.environment-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.environment-switcher span {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #9ca9c3;
+}
+
+.environment-switcher select {
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 6px 24px 6px 10px;
+  background: rgba(9, 17, 32, 0.85);
+  color: #e2e8f0;
+  font-size: 12px;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
+  min-width: 180px;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(148, 163, 184, 0.7) 50%),
+    linear-gradient(135deg, rgba(148, 163, 184, 0.7) 50%, transparent 50%);
+  background-position: calc(100% - 14px) calc(50% - 3px), calc(100% - 9px) calc(50% - 3px);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
+.environment-switcher select:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
+}
+
+.environment-switcher select:disabled {
+  opacity: 0.6;
+  cursor: progress;
+  background-image: none;
+}
+
 .primary-button,
 .accent-button,
 .ghost-button,

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -36,8 +36,13 @@ async function setupGitWorkspace() {
     settingsPath,
     JSON.stringify(
       {
-        repoDir,
-        workspaceRoot,
+        environments: {
+          test: {
+            repoDir,
+            workspaceRoot,
+          },
+        },
+        activeEnvironment: "test",
       },
       null,
       2,


### PR DESCRIPTION
## Summary
- refactor the settings manager to store multiple named environments and expose active-environment helpers
- add IPC bridges and renderer UI to select environments at runtime while refreshing workspace state
- update documentation and tests to reflect the new settings schema

## Testing
- npm run test:unit *(fails: no tests found for pattern tests/unit/**/*.test.js)*
- npm run test:e2e *(fails: electron process missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_6900b07afc84832eb8c539acfb8fb4b0