### PR TITLE
Enhance workspace status tooltip and delete dialog

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -73,6 +73,27 @@
         </section>
       </main>
 
+      <div id="delete-dialog-overlay" class="dialog-overlay is-hidden" aria-hidden="true">
+        <div id="delete-dialog-backdrop" class="dialog-backdrop" data-action="dismiss"></div>
+        <div
+          id="delete-dialog-panel"
+          class="dialog-panel"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-dialog-title"
+          aria-describedby="delete-dialog-message delete-dialog-warning"
+        >
+          <h2 id="delete-dialog-title">Remove workspace?</h2>
+          <p id="delete-dialog-message" class="dialog-message"></p>
+          <div id="delete-dialog-warning" class="dialog-warning is-hidden"></div>
+          <ul id="delete-dialog-summary" class="dialog-summary"></ul>
+          <div class="dialog-footer">
+            <button type="button" class="ghost-button" id="delete-dialog-cancel">Cancel</button>
+            <button type="button" class="danger-button" id="delete-dialog-confirm">Delete workspace</button>
+          </div>
+        </div>
+      </div>
+
       <div id="toast-container" class="toast-container"></div>
     </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -699,6 +699,92 @@ code {
   font-size: 0.85rem;
 }
 
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 950;
+}
+
+.dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 10, 24, 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.dialog-panel {
+  position: relative;
+  width: min(420px, calc(100% - 32px));
+  max-width: 420px;
+  border-radius: 10px;
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  background: linear-gradient(145deg, rgba(9, 17, 32, 0.96), rgba(9, 13, 26, 0.98));
+  box-shadow: 0 28px 60px -34px rgba(15, 23, 42, 0.95);
+  padding: 20px 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dialog-panel h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #f8fafc;
+}
+
+.dialog-message {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.dialog-warning {
+  border-radius: 8px;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(190, 18, 60, 0.18);
+  color: #fecaca;
+  font-size: 0.85rem;
+  padding: 10px 12px;
+  line-height: 1.35;
+}
+
+.dialog-summary {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.dialog-summary li {
+  list-style: disc;
+}
+
+.dialog-summary .dialog-sublist {
+  margin-top: 4px;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: #cbd5f5;
+}
+
+.dialog-summary .dialog-sublist li {
+  list-style: circle;
+  font-size: 0.8rem;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .toast-container {
   position: fixed;
   right: 20px;


### PR DESCRIPTION
## Summary
- add a styled delete confirmation dialog that highlights workspace details and pending changes
- surface git status sample information from the backend when hovering status icons
- add the supporting markup and styles for the confirmation overlay

## Testing
- npm run test:unit *(fails: Could not find '/workspace/wtm-worktree-manager/tests/unit/**/*.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_6900ba578538832e857cc8c67441cac9