### PR TITLE
Add configurable quick commands and terminal tab management

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,15 @@ alongside the rest of your dotfiles. By default the app creates
       "workspaceRoot": "/absolute/path/to/worktrees"
     }
   },
-  "activeEnvironment": "default"
+  "activeEnvironment": "default",
+  "quickAccess": [
+    { "key": "npm-install", "label": "npm i", "quickCommand": "npm i" },
+    {
+      "key": "lerna-bootstrap",
+      "label": "npm run lerna:bootstrap",
+      "quickCommand": "npm run lerna:bootstrap"
+    }
+  ]
 }
 ```
 
@@ -88,6 +96,12 @@ with multiple repositories. The app exposes a dropdown in the header that lets
 you switch between the configured environments at runtime. The
 `activeEnvironment` key selects which environment is used when the app starts.
 All paths are resolved to absolute locations automatically.
+
+Use the `quickAccess` array to configure the pre-defined terminal tabs that
+appear for each workspace. Each entry accepts a unique `key`, a human-friendly
+`label`, and the `quickCommand` to execute when the terminal is opened for the
+first time. Provide an empty array to disable the presets entirely and rely on
+the new “+” button to launch ad-hoc terminals.
 
 To use an alternative settings location (useful for scripting or tests), set
 the `WTM_SETTINGS_PATH` environment variable to your desired JSON file.
@@ -99,5 +113,7 @@ the `WTM_SETTINGS_PATH` environment variable to your desired JSON file.
 - Worktree removal is performed via `git worktree remove`. The UI asks for
   confirmation if uncommitted changes are present unless deletion is forced.
 - Use the **Refresh** button whenever worktrees change outside the app.
+- Terminal tabs can now be closed individually. Preset tabs remain available
+  (turning red when stopped) while ad-hoc tabs disappear once closed.
 
 Happy hacking! ♟️

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -119,9 +119,11 @@ function exposeSettingsHandlers() {
     await settingsManager.load();
     const environments = settingsManager.listEnvironments();
     const active = settingsManager.getActiveEnvironment();
+    const quickAccess = settingsManager.getQuickAccess();
     return {
       environments,
       activeEnvironment: active.name,
+      quickAccess,
     };
   });
 
@@ -134,11 +136,13 @@ function exposeSettingsHandlers() {
     const environment = await settingsManager.setActiveEnvironment(name);
     workspaceManager.configure(environment);
     const environments = settingsManager.listEnvironments();
+    const quickAccess = settingsManager.getQuickAccess();
 
     return {
       activeEnvironment: environment.name,
       environment,
       environments,
+      quickAccess,
     };
   });
 }

--- a/src/main/settingsManager.js
+++ b/src/main/settingsManager.js
@@ -3,6 +3,19 @@ const { mkdir } = require("node:fs/promises");
 const { homedir } = require("node:os");
 const { dirname, join, resolve } = require("node:path");
 
+const DEFAULT_QUICK_ACCESS = [
+  {
+    key: "npm-install",
+    label: "npm i",
+    quickCommand: "npm i",
+  },
+  {
+    key: "lerna-bootstrap",
+    label: "npm run lerna:bootstrap",
+    quickCommand: "npm run lerna:bootstrap",
+  },
+];
+
 function defaultSettings() {
   const home = homedir();
   const defaultEnvironment = {
@@ -15,6 +28,7 @@ function defaultSettings() {
       default: defaultEnvironment,
     },
     activeEnvironment: "default",
+    quickAccess: DEFAULT_QUICK_ACCESS,
   };
 }
 
@@ -63,11 +77,18 @@ class SettingsManager {
 
     const environments = this.normalizeEnvironmentMap(normalizedRaw.environments, defaults);
 
-    const activeEnvironment = this.resolveActiveEnvironment(normalizedRaw.activeEnvironment, environments, defaults);
+    const activeEnvironment = this.resolveActiveEnvironment(
+      normalizedRaw.activeEnvironment,
+      environments,
+      defaults,
+    );
+
+    const quickAccess = this.normalizeQuickAccess(normalizedRaw.quickAccess, defaults.quickAccess);
 
     return {
       environments,
       activeEnvironment,
+      quickAccess,
     };
   }
 
@@ -83,6 +104,7 @@ class SettingsManager {
           },
         },
         activeEnvironment: "default",
+        quickAccess: defaults.quickAccess,
       };
     }
 
@@ -92,7 +114,97 @@ class SettingsManager {
     return {
       environments,
       activeEnvironment: source.activeEnvironment ?? defaults.activeEnvironment,
+      quickAccess: Array.isArray(source.quickAccess) ? source.quickAccess : defaults.quickAccess,
     };
+  }
+
+  normalizeQuickAccess(rawList, defaultList) {
+    const hasUserList = Array.isArray(rawList);
+    const sourceList = hasUserList ? rawList : defaultList;
+    const normalized = [];
+    const seenKeys = new Set();
+
+    sourceList.forEach((entry, index) => {
+      const normalizedEntry = this.normalizeQuickAccessEntry(entry, index);
+      if (!normalizedEntry) {
+        return;
+      }
+      let key = normalizedEntry.key;
+      let counter = 1;
+      while (seenKeys.has(key)) {
+        key = `${normalizedEntry.key}-${counter += 1}`;
+      }
+      seenKeys.add(key);
+      normalized.push({
+        key,
+        label: normalizedEntry.label,
+        quickCommand: normalizedEntry.quickCommand,
+      });
+    });
+
+    if (normalized.length === 0) {
+      if (hasUserList && sourceList.length === 0) {
+        return [];
+      }
+      return defaultList.map((item) => ({ ...item }));
+    }
+
+    return normalized;
+  }
+
+  normalizeQuickAccessEntry(entry, index) {
+    if (!entry || (typeof entry !== "object" && typeof entry !== "string")) {
+      return null;
+    }
+
+    if (typeof entry === "string") {
+      const label = entry.trim();
+      if (!label) {
+        return null;
+      }
+      return {
+        key: this.slugify(label) || `slot-${index + 1}`,
+        label,
+        quickCommand: label,
+      };
+    }
+
+    const labelCandidate = this.extractString(entry.label) || this.extractString(entry.name);
+    const commandCandidate =
+      this.extractString(entry.quickCommand) || this.extractString(entry.command) || labelCandidate;
+
+    if (!labelCandidate && !commandCandidate) {
+      return null;
+    }
+
+    const label = labelCandidate || commandCandidate || `Command ${index + 1}`;
+    const quickCommand = commandCandidate || label;
+    const keySource = this.extractString(entry.key) || label;
+    const key = this.slugify(keySource) || `slot-${index + 1}`;
+
+    return {
+      key,
+      label,
+      quickCommand,
+    };
+  }
+
+  extractString(value) {
+    if (typeof value !== "string") {
+      return "";
+    }
+    return value.trim();
+  }
+
+  slugify(value) {
+    if (!value) {
+      return "";
+    }
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
   }
 
   normalizeEnvironmentMap(environmentsRaw, defaults) {
@@ -182,6 +294,11 @@ class SettingsManager {
       workspaceRoot: config.workspaceRoot,
       isActive: name === settings.activeEnvironment,
     }));
+  }
+
+  getQuickAccess() {
+    const settings = this.getSettings();
+    return settings.quickAccess.map((item) => ({ ...item }));
   }
 
   getEnvironment(name) {

--- a/src/main/terminalManager.js
+++ b/src/main/terminalManager.js
@@ -45,6 +45,7 @@ class TerminalManager {
       cols = 80,
       rows = 24,
       env = {},
+      label,
     } = params;
 
     if (!workspacePath || !slot) {
@@ -92,7 +93,7 @@ class TerminalManager {
       webContentsId,
     );
 
-    await terminalSessionStore.ensureTerminal(absPath, slot);
+    await terminalSessionStore.ensureTerminal(absPath, slot, { label });
 
     const session = this.sessions.get(result.sessionId);
     if (session && savedTerminal) {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -605,14 +605,14 @@ code {
 }
 
 .terminal-tab {
+  display: inline-flex;
+  align-items: stretch;
   border-radius: 4px 4px 0 0;
   border: 1px solid rgba(71, 85, 105, 0.4);
-  padding: 4px 8px;
-  font-size: 11px;
-  color: #cbd5f5;
   background: rgba(15, 23, 42, 0.75);
-  cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease;
+  color: #cbd5f5;
+  overflow: hidden;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
 
 .terminal-tab.is-exited {
@@ -626,8 +626,78 @@ code {
   color: #e2e8f0;
 }
 
-.terminal-tab:hover:not(.is-active) {
+.terminal-tab:not(.is-active):hover {
   border-color: rgba(148, 163, 184, 0.45);
+}
+
+.terminal-tab-button,
+.terminal-tab-close {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.terminal-tab-button {
+  font-size: 11px;
+  line-height: 1.2;
+  gap: 4px;
+}
+
+.terminal-tab-close {
+  font-size: 12px;
+  padding: 4px 6px;
+  border-left: 1px solid rgba(71, 85, 105, 0.4);
+  line-height: 1;
+  opacity: 0.85;
+  transition: background 0.12s ease, opacity 0.12s ease;
+}
+
+.terminal-tab-close:hover {
+  background: rgba(148, 163, 184, 0.18);
+  opacity: 1;
+}
+
+.terminal-tab.is-active .terminal-tab-close {
+  border-left-color: rgba(125, 211, 252, 0.35);
+}
+
+.terminal-tab.is-exited .terminal-tab-close {
+  border-left-color: rgba(248, 113, 113, 0.35);
+}
+
+.terminal-tab-button:focus-visible,
+.terminal-tab-close:focus-visible,
+.terminal-tab-add:focus-visible {
+  outline: 2px solid rgba(125, 211, 252, 0.6);
+  outline-offset: -2px;
+}
+
+.terminal-tab-add {
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  border: 1px dashed rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.6);
+  color: #94a3b8;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+.terminal-tab-add:hover {
+  border-color: rgba(148, 163, 184, 0.7);
+  background: rgba(30, 41, 59, 0.85);
+  color: #e2e8f0;
 }
 
 .terminal-panels {


### PR DESCRIPTION
## Summary
- allow the settings manager and IPC layer to expose a configurable quick access command list
- persist terminal labels in the session store and pass them through session creation
- add UI controls for adding/closing terminals, update styling, and document the new behaviour

## Testing
- npm test *(fails: test suite not present in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6900c7d10ee4832ea95b00b3c461176a