### PR TITLE
Add CLI completions with dynamic branch and ticket suggestions

### DIFF
--- a/scripts/completions/wtm.bash
+++ b/scripts/completions/wtm.bash
@@ -1,0 +1,117 @@
+# bash completion for wtm
+if ! type _init_completion >/dev/null 2>&1; then
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+        . /usr/share/bash-completion/bash_completion
+    fi
+fi
+
+_wtm()
+{
+    local cur prev words cword
+    _init_completion -n = || return
+
+    if (( cword == 1 )); then
+        COMPREPLY=( $(compgen -W "init completions workspace gui" -- "$cur") )
+        return
+    fi
+
+    prev="${words[$cword-1]}"
+    case "${words[1]}" in
+        init|gui)
+            return
+            ;;
+        completions)
+            if (( cword == 2 )); then
+                COMPREPLY=( $(compgen -W "generate suggest" -- "$cur") )
+                return
+            fi
+            case "${words[2]}" in
+                generate)
+                    if (( cword == 3 )); then
+                        COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") )
+                    fi
+                    ;;
+                suggest)
+                    if [[ "$prev" == "--shell" ]]; then
+                        COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") )
+                        return
+                    fi
+                    if [[ "$prev" == "--contains" ]]; then
+                        return
+                    fi
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--contains --shell --json" -- "$cur") )
+                        return
+                    fi
+                    if (( cword == 3 )); then
+                        COMPREPLY=( $(compgen -W "branches" -- "$cur") )
+                        return
+                    fi
+                    ;;
+            esac
+            ;;
+        workspace)
+            if (( cword == 2 )); then
+                COMPREPLY=( $(compgen -W "list create attach delete move telemetry" -- "$cur") )
+                return
+            fi
+            case "${words[2]}" in
+                list)
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--json" -- "$cur") )
+                    fi
+                    ;;
+                create)
+                    if [[ "$prev" == "--from" || "$prev" == "--path" ]]; then
+                        return
+                    fi
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--from --path --json" -- "$cur") )
+                    else
+                        COMPREPLY=( $(__wtm_branch_suggestions "$cur") )
+                    fi
+                    ;;
+                attach)
+                    if [[ "$prev" == "--path" ]]; then
+                        return
+                    fi
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--path --json" -- "$cur") )
+                    else
+                        COMPREPLY=( $(__wtm_branch_suggestions "$cur") )
+                    fi
+                    ;;
+                delete)
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--name --branch --path --force --json" -- "$cur") )
+                    fi
+                    ;;
+                move)
+                    if [[ "$prev" == "--to" ]]; then
+                        return
+                    fi
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--name --branch --path --to --force --json" -- "$cur") )
+                    fi
+                    ;;
+                telemetry)
+                    if [[ "$cur" == --* ]]; then
+                        COMPREPLY=( $(compgen -W "--name --branch --path --json --no-status --no-size" -- "$cur") )
+                    fi
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+__wtm_branch_suggestions()
+{
+    local query="$1"
+    if [[ -z "$query" ]]; then
+        wtm completions suggest branches --shell bash 2>/dev/null
+    else
+        wtm completions suggest branches --shell bash --contains "$query" 2>/dev/null
+    fi
+}
+
+complete -F _wtm wtm

--- a/scripts/completions/wtm.zsh
+++ b/scripts/completions/wtm.zsh
@@ -1,0 +1,123 @@
+#compdef wtm
+
+_wtm() {
+    local cur prev
+    cur=${words[CURRENT]}
+    prev=${words[CURRENT-1]}
+
+    if (( CURRENT == 2 )); then
+        _values 'command' init completions workspace gui
+        return
+    fi
+
+    case ${words[2]} in
+        completions)
+            if (( CURRENT == 3 )); then
+                _values 'subcommand' generate suggest
+                return
+            fi
+            case ${words[3]} in
+                generate)
+                    if (( CURRENT == 4 )); then
+                        _values 'shell' bash zsh
+                    fi
+                    ;;
+                suggest)
+                    if [[ $prev == --shell ]]; then
+                        _values 'shell' bash zsh
+                        return
+                    fi
+                    if [[ $prev == --contains ]]; then
+                        return
+                    fi
+                    if [[ $cur == --* ]]; then
+                        _values 'option' --contains --shell --json
+                        return
+                    fi
+                    if (( CURRENT == 4 )); then
+                        _values 'domain' branches
+                        return
+                    fi
+                    ;;
+            esac
+            ;;
+        workspace)
+            if (( CURRENT == 3 )); then
+                _values 'subcommand' list create attach delete move telemetry
+                return
+            fi
+            case ${words[3]} in
+                list)
+                    _values 'option' --json
+                    ;;
+                create)
+                    if [[ $prev == --from ]]; then
+                        _message 'upstream reference'
+                        return
+                    fi
+                    if [[ $prev == --path ]]; then
+                        _files -/
+                        return
+                    fi
+                    if [[ $cur == --* ]]; then
+                        _values 'option' --from --path --json
+                        return
+                    fi
+                    if (( CURRENT == 4 )); then
+                        __wtm_zsh_branch_suggestions "$cur"
+                        return
+                    fi
+                    ;;
+                attach)
+                    if [[ $prev == --path ]]; then
+                        _files -/
+                        return
+                    fi
+                    if [[ $cur == --* ]]; then
+                        _values 'option' --path --json
+                        return
+                    fi
+                    if (( CURRENT == 4 )); then
+                        __wtm_zsh_branch_suggestions "$cur"
+                        return
+                    fi
+                    ;;
+                delete)
+                    if [[ $cur == --* ]]; then
+                        _values 'option' --name --branch --path --force --json
+                        return
+                    fi
+                    ;;
+                move)
+                    if [[ $prev == --to ]]; then
+                        _files -/
+                        return
+                    fi
+                    if [[ $cur == --* ]]; then
+                        _values 'option' --name --branch --path --to --force --json
+                        return
+                    fi
+                    ;;
+                telemetry)
+                    if [[ $cur == --* ]]; then
+                        _values 'option' --name --branch --path --json --no-status --no-size
+                        return
+                    fi
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+__wtm_zsh_branch_suggestions() {
+    local query=$1
+    local -a suggestions
+    if [[ -z $query ]]; then
+        suggestions=(${(f)$(wtm completions suggest branches --shell zsh 2>/dev/null)})
+    else
+        suggestions=(${(f)$(wtm completions suggest branches --shell zsh --contains "$query" 2>/dev/null)})
+    fi
+    _describe 'branch' suggestions
+}
+
+compdef _wtm wtm

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,0 +1,184 @@
+use crate::git::{find_repo_root, list_branches, list_remote_branches};
+use crate::jira;
+use crate::wtm_paths::branch_dir_name;
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompletionSuggestion {
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum SuggestionDomain {
+    Branches,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum SuggestionShellFormat {
+    Bash,
+    Zsh,
+}
+
+pub fn generate_shell_completion(shell: CompletionShell) -> Result<String> {
+    let script = match shell {
+        CompletionShell::Bash => include_str!("../../scripts/completions/wtm.bash"),
+        CompletionShell::Zsh => include_str!("../../scripts/completions/wtm.zsh"),
+    };
+    Ok(script.to_string())
+}
+
+pub fn collect_suggestions(
+    domain: SuggestionDomain,
+    repo_root: &Path,
+) -> Result<Vec<CompletionSuggestion>> {
+    match domain {
+        SuggestionDomain::Branches => branch_suggestions(repo_root),
+    }
+}
+
+pub fn format_suggestions(
+    suggestions: &[CompletionSuggestion],
+    query: Option<&str>,
+    shell: Option<SuggestionShellFormat>,
+) -> Vec<String> {
+    let filtered = filter_suggestions(suggestions, query);
+    match shell {
+        Some(SuggestionShellFormat::Bash) => filtered
+            .into_iter()
+            .map(|suggestion| format_for_bash(&suggestion))
+            .collect(),
+        Some(SuggestionShellFormat::Zsh) => filtered
+            .into_iter()
+            .map(|suggestion| format_for_zsh(&suggestion))
+            .collect(),
+        None => filtered.into_iter().map(|s| s.value).collect(),
+    }
+}
+
+pub fn current_repo_root() -> Result<std::path::PathBuf> {
+    let cwd = std::env::current_dir().context("unable to determine current directory")?;
+    find_repo_root(&cwd)
+}
+
+fn branch_suggestions(repo_root: &Path) -> Result<Vec<CompletionSuggestion>> {
+    let mut seen = HashSet::new();
+    let mut suggestions = Vec::new();
+
+    if let Ok(tickets) = jira::cached_tickets(repo_root) {
+        for ticket in tickets {
+            let slug = ticket.slug();
+            if seen.insert(slug.clone()) {
+                suggestions.push(CompletionSuggestion {
+                    value: slug,
+                    description: Some(format!("{} {}", ticket.key, ticket.summary)),
+                    upstream: None,
+                    source: Some("ticket".into()),
+                });
+            }
+        }
+    }
+
+    if let Ok(local_branches) = list_branches(repo_root) {
+        for branch in local_branches {
+            if seen.insert(branch.clone()) {
+                suggestions.push(CompletionSuggestion {
+                    value: branch,
+                    description: Some("local branch".into()),
+                    upstream: None,
+                    source: Some("local".into()),
+                });
+            }
+        }
+    }
+
+    if let Ok(remote_branches) = list_remote_branches(repo_root) {
+        for remote in remote_branches {
+            if let Some((remote_name, branch_name)) = split_remote_branch(&remote) {
+                let sanitized = branch_dir_name(&branch_name);
+                if seen.insert(sanitized.clone()) {
+                    let description = if sanitized == branch_name {
+                        format!("remote branch {remote}")
+                    } else {
+                        format!("remote branch {remote} ⇒ {sanitized}")
+                    };
+                    suggestions.push(CompletionSuggestion {
+                        value: sanitized,
+                        description: Some(description),
+                        upstream: Some(remote),
+                        source: Some(format!("remote:{remote_name}")),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(suggestions)
+}
+
+fn filter_suggestions(
+    suggestions: &[CompletionSuggestion],
+    query: Option<&str>,
+) -> Vec<CompletionSuggestion> {
+    if let Some(query) = query {
+        let needle = query.to_lowercase();
+        suggestions
+            .iter()
+            .filter(|suggestion| {
+                let mut haystacks = vec![suggestion.value.to_lowercase()];
+                if let Some(description) = &suggestion.description {
+                    haystacks.push(description.to_lowercase());
+                }
+                if let Some(upstream) = &suggestion.upstream {
+                    haystacks.push(upstream.to_lowercase());
+                }
+                haystacks.iter().any(|text| text.contains(&needle))
+            })
+            .cloned()
+            .collect()
+    } else {
+        suggestions.to_vec()
+    }
+}
+
+fn format_for_bash(suggestion: &CompletionSuggestion) -> String {
+    if let Some(description) = suggestion.description.as_deref() {
+        format!("{}\t{}", suggestion.value, description)
+    } else {
+        suggestion.value.clone()
+    }
+}
+
+fn format_for_zsh(suggestion: &CompletionSuggestion) -> String {
+    if let Some(description) = suggestion.description.as_deref() {
+        format!("{}:{}", suggestion.value, description)
+    } else {
+        suggestion.value.clone()
+    }
+}
+
+fn split_remote_branch(reference: &str) -> Option<(String, String)> {
+    let mut parts = reference.splitn(2, '/');
+    let remote = parts.next().unwrap_or_default();
+    let branch = parts.next().unwrap_or("");
+    if branch.is_empty() {
+        None
+    } else {
+        Some((remote.to_string(), branch.to_string()))
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,3 @@
+pub mod completions;
 pub mod init;
+pub mod workspace;

--- a/src/commands/workspace.rs
+++ b/src/commands/workspace.rs
@@ -1,0 +1,408 @@
+use crate::git::status::{status as git_status, GitStatusSummary};
+use crate::git::{
+    add_worktree, add_worktree_for_branch, add_worktree_from_upstream, list_worktrees,
+    move_worktree, remove_worktree, WorktreeInfo,
+};
+use crate::wtm_paths::{
+    branch_dir_name, ensure_workspace_root, next_available_workspace_path, sanitize_branch_name,
+    workspace_root,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct WorkspaceSelector {
+    /// Match a workspace by its directory name
+    #[arg(long, value_name = "NAME")]
+    pub name: Option<String>,
+    /// Match a workspace by the git branch it is attached to
+    #[arg(long, value_name = "BRANCH")]
+    pub branch: Option<String>,
+    /// Match a workspace by its filesystem path (relative paths resolve within `.wtm/workspaces`)
+    #[arg(long, value_name = "PATH")]
+    pub path: Option<PathBuf>,
+}
+
+impl WorkspaceSelector {
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none() && self.branch.is_none() && self.path.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceSummary {
+    pub name: String,
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub head: Option<String>,
+    pub is_locked: bool,
+    pub is_prunable: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceTelemetry {
+    pub summary: WorkspaceSummary,
+    pub status: Option<GitStatusSummary>,
+    pub status_error: Option<String>,
+    pub disk_usage_bytes: Option<u64>,
+    pub disk_usage_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TelemetryOptions {
+    pub include_status: bool,
+    pub include_disk_usage: bool,
+}
+
+impl Default for TelemetryOptions {
+    fn default() -> Self {
+        Self {
+            include_status: true,
+            include_disk_usage: true,
+        }
+    }
+}
+
+pub fn list_workspaces(repo_root: &Path) -> Result<Vec<WorkspaceSummary>> {
+    let worktrees = list_worktrees(repo_root)?;
+    Ok(worktrees
+        .iter()
+        .map(WorkspaceSummary::from_worktree)
+        .collect())
+}
+
+pub fn create_workspace(
+    repo_root: &Path,
+    branch: &str,
+    upstream: Option<&str>,
+    explicit_path: Option<&Path>,
+) -> Result<WorkspaceSummary> {
+    let sanitized_branch = sanitize_branch_name(branch);
+    if sanitized_branch.is_empty() {
+        bail!("Branch name is required.");
+    }
+
+    let workspace_root = ensure_workspace_root(repo_root).with_context(|| {
+        format!(
+            "unable to prepare workspace root under {}",
+            repo_root.display()
+        )
+    })?;
+
+    let target_path = resolve_target_path(
+        &workspace_root,
+        explicit_path,
+        &branch_dir_name(&sanitized_branch),
+    );
+
+    if target_path.exists() {
+        bail!(
+            "Target workspace directory {} already exists",
+            target_path.display()
+        );
+    }
+
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create parent directories for workspace at {}",
+                target_path.display()
+            )
+        })?;
+    }
+
+    if let Some(upstream) = upstream {
+        add_worktree_from_upstream(repo_root, &target_path, &sanitized_branch, upstream)?;
+    } else {
+        add_worktree(repo_root, &target_path, Some(&sanitized_branch))?;
+    }
+
+    locate_workspace_summary(repo_root, &target_path)
+}
+
+pub fn attach_workspace(
+    repo_root: &Path,
+    branch: &str,
+    explicit_path: Option<&Path>,
+) -> Result<WorkspaceSummary> {
+    let trimmed = branch.trim();
+    if trimmed.is_empty() {
+        bail!("Branch name is required.");
+    }
+
+    let workspace_root = ensure_workspace_root(repo_root).with_context(|| {
+        format!(
+            "unable to prepare workspace root under {}",
+            repo_root.display()
+        )
+    })?;
+
+    let target_path =
+        resolve_target_path(&workspace_root, explicit_path, &branch_dir_name(trimmed));
+
+    if target_path.exists() {
+        bail!(
+            "Target workspace directory {} already exists",
+            target_path.display()
+        );
+    }
+
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create parent directories for workspace at {}",
+                target_path.display()
+            )
+        })?;
+    }
+
+    add_worktree_for_branch(repo_root, &target_path, trimmed)?;
+    locate_workspace_summary(repo_root, &target_path)
+}
+
+pub fn delete_workspace(
+    repo_root: &Path,
+    selector: &WorkspaceSelector,
+    force: bool,
+) -> Result<WorkspaceSummary> {
+    if selector.is_empty() {
+        bail!("Provide at least one selector (name, branch or path) to delete a workspace.");
+    }
+
+    let worktrees = list_worktrees(repo_root)?;
+    let workspace_root = workspace_root(repo_root);
+    let worktree = resolve_single_workspace(&worktrees, &workspace_root, selector)?;
+
+    if worktree.path == repo_root {
+        bail!("Refusing to delete the primary repository worktree.");
+    }
+
+    let summary = WorkspaceSummary::from_worktree(worktree);
+    remove_worktree(repo_root, &worktree.path, force)?;
+    Ok(summary)
+}
+
+pub fn move_workspace(
+    repo_root: &Path,
+    selector: &WorkspaceSelector,
+    destination: &Path,
+    force: bool,
+) -> Result<WorkspaceSummary> {
+    if selector.is_empty() {
+        bail!("Provide at least one selector (name, branch or path) to move a workspace.");
+    }
+
+    let worktrees = list_worktrees(repo_root)?;
+    let workspace_root = workspace_root(repo_root);
+    let worktree = resolve_single_workspace(&worktrees, &workspace_root, selector)?;
+
+    if worktree.path == repo_root {
+        bail!("Refusing to move the primary repository worktree.");
+    }
+
+    let workspace_root = ensure_workspace_root(repo_root).with_context(|| {
+        format!(
+            "unable to prepare workspace root under {}",
+            repo_root.display()
+        )
+    })?;
+    let target_path =
+        resolve_target_path(&workspace_root, Some(destination), worktree.name().as_str());
+
+    if target_path.exists() {
+        bail!(
+            "Destination workspace directory {} already exists",
+            target_path.display()
+        );
+    }
+
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create parent directories for workspace at {}",
+                target_path.display()
+            )
+        })?;
+    }
+
+    move_worktree(repo_root, &worktree.path, &target_path, force)?;
+    locate_workspace_summary(repo_root, &target_path)
+}
+
+pub fn workspace_telemetry(
+    repo_root: &Path,
+    selector: &WorkspaceSelector,
+    options: TelemetryOptions,
+) -> Result<Vec<WorkspaceTelemetry>> {
+    let worktrees = list_worktrees(repo_root)?;
+    let workspace_root = workspace_root(repo_root);
+    let matches = if selector.is_empty() {
+        worktrees.iter().collect()
+    } else {
+        resolve_workspaces(&worktrees, &workspace_root, selector)?
+    };
+
+    matches
+        .into_iter()
+        .map(|worktree| collect_workspace_telemetry(worktree, options))
+        .collect()
+}
+
+fn collect_workspace_telemetry(
+    worktree: &WorktreeInfo,
+    options: TelemetryOptions,
+) -> Result<WorkspaceTelemetry> {
+    let mut telemetry = WorkspaceTelemetry {
+        summary: WorkspaceSummary::from_worktree(worktree),
+        status: None,
+        status_error: None,
+        disk_usage_bytes: None,
+        disk_usage_error: None,
+    };
+
+    if options.include_status {
+        match git_status(worktree.path()) {
+            Ok(summary) => telemetry.status = Some(summary),
+            Err(err) => telemetry.status_error = Some(err.to_string()),
+        }
+    }
+
+    if options.include_disk_usage {
+        match directory_size(worktree.path()) {
+            Ok(size) => telemetry.disk_usage_bytes = Some(size),
+            Err(err) => telemetry.disk_usage_error = Some(err.to_string()),
+        }
+    }
+
+    Ok(telemetry)
+}
+
+fn resolve_target_path(
+    workspace_root: &Path,
+    explicit: Option<&Path>,
+    fallback_name: &str,
+) -> PathBuf {
+    match explicit {
+        Some(path) => normalise_workspace_path(path, workspace_root),
+        None => next_available_workspace_path(workspace_root, fallback_name),
+    }
+}
+
+fn normalise_workspace_path(path: &Path, workspace_root: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workspace_root.join(path)
+    }
+}
+
+fn locate_workspace_summary(repo_root: &Path, path: &Path) -> Result<WorkspaceSummary> {
+    let worktrees = list_worktrees(repo_root)?;
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo_root.join(path)
+    };
+
+    worktrees
+        .iter()
+        .find(|wt| wt.path == absolute)
+        .map(WorkspaceSummary::from_worktree)
+        .ok_or_else(|| anyhow!("unable to locate workspace at {}", absolute.display()))
+}
+
+fn resolve_workspaces<'a>(
+    worktrees: &'a [WorktreeInfo],
+    workspace_root: &Path,
+    selector: &WorkspaceSelector,
+) -> Result<Vec<&'a WorktreeInfo>> {
+    let mut matches: Vec<&WorktreeInfo> = worktrees
+        .iter()
+        .filter(|worktree| matches_selector(worktree, workspace_root, selector))
+        .collect();
+
+    if matches.is_empty() {
+        bail!("No workspaces match the provided selector.");
+    }
+
+    matches.sort_by_key(|wt| wt.name());
+    Ok(matches)
+}
+
+fn resolve_single_workspace<'a>(
+    worktrees: &'a [WorktreeInfo],
+    workspace_root: &Path,
+    selector: &WorkspaceSelector,
+) -> Result<&'a WorktreeInfo> {
+    let matches = resolve_workspaces(worktrees, workspace_root, selector)?;
+    if matches.len() > 1 {
+        bail!("Multiple workspaces match the provided selector; narrow the query.");
+    }
+    Ok(matches[0])
+}
+
+fn matches_selector(
+    worktree: &WorktreeInfo,
+    workspace_root: &Path,
+    selector: &WorkspaceSelector,
+) -> bool {
+    if let Some(name) = selector.name.as_deref() {
+        if worktree.name() != name {
+            return false;
+        }
+    }
+
+    if let Some(branch) = selector.branch.as_deref() {
+        if worktree.branch.as_deref() != Some(branch) {
+            return false;
+        }
+    }
+
+    if let Some(path) = selector.path.as_deref() {
+        let target = normalise_workspace_path(path, workspace_root);
+        if worktree.path != target {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn directory_size(path: &Path) -> Result<u64> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect metadata for {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Ok(0);
+    }
+    if metadata.is_file() {
+        return Ok(metadata.len());
+    }
+    if metadata.is_dir() {
+        let mut total = 0u64;
+        for entry in fs::read_dir(path)
+            .with_context(|| format!("failed to enumerate directory {}", path.display()))?
+        {
+            let entry =
+                entry.with_context(|| format!("failed to read entry inside {}", path.display()))?;
+            total += directory_size(&entry.path())?;
+        }
+        return Ok(total);
+    }
+    Ok(0)
+}
+
+impl WorkspaceSummary {
+    fn from_worktree(worktree: &WorktreeInfo) -> Self {
+        Self {
+            name: worktree.name(),
+            path: worktree.path.clone(),
+            branch: worktree.branch.clone(),
+            head: worktree.head.clone(),
+            is_locked: worktree.is_locked,
+            is_prunable: worktree.is_prunable,
+        }
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -118,6 +118,22 @@ pub fn add_worktree_from_upstream(
     run_git(args, repo_root).map(|_| ())
 }
 
+/// Move an existing worktree via `git worktree move`.
+pub fn move_worktree(
+    repo_root: &Path,
+    source: &Path,
+    destination: &Path,
+    force: bool,
+) -> Result<()> {
+    let mut args: Vec<String> = vec!["worktree".into(), "move".into()];
+    if force {
+        args.push("--force".into());
+    }
+    args.push(source.to_string_lossy().into_owned());
+    args.push(destination.to_string_lossy().into_owned());
+    run_git(args, repo_root).map(|_| ())
+}
+
 /// Remove an existing worktree via `git worktree remove`.
 pub fn remove_worktree(repo_root: &Path, path: &Path, force: bool) -> Result<()> {
     let mut args: Vec<String> = vec!["worktree".into(), "remove".into()];

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -1,8 +1,9 @@
 use super::run_git;
 use anyhow::Result;
+use serde::Serialize;
 use std::path::Path;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
 pub struct GitStatusSummary {
     pub branch: Option<String>,
     pub upstream: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,14 +8,21 @@ mod tui;
 mod wtm_paths;
 
 use anyhow::{bail, Context, Result};
-use clap::{Parser, Subcommand};
-use commands::init::init_command;
-use config::QuickAction;
-use git::{add_worktree, find_repo_root, list_worktrees, remove_worktree, WorktreeInfo};
-use std::path::PathBuf;
-use wtm_paths::{
-    branch_dir_name, ensure_workspace_root, next_available_workspace_path, sanitize_branch_name,
+use clap::{ArgAction, Parser, Subcommand};
+use commands::completions::{
+    collect_suggestions, current_repo_root, format_suggestions, generate_shell_completion,
+    CompletionShell, SuggestionDomain, SuggestionShellFormat,
 };
+use commands::init::init_command;
+use commands::workspace::{
+    attach_workspace, create_workspace, delete_workspace, list_workspaces, move_workspace,
+    workspace_telemetry, TelemetryOptions, WorkspaceSelector, WorkspaceSummary, WorkspaceTelemetry,
+};
+use config::QuickAction;
+use git::{find_repo_root, list_worktrees, WorktreeInfo};
+use serde_json::to_string_pretty;
+use std::cmp::min;
+use std::path::PathBuf;
 
 /// WTM command line interface.
 #[derive(Parser, Debug)]
@@ -37,31 +44,117 @@ enum Commands {
         #[arg(default_value = ".")]
         path: PathBuf,
     },
-    /// Manage git worktrees via the CLI
-    Worktree {
+    /// Shell completion utilities
+    Completions {
         #[command(subcommand)]
-        command: WorktreeCommands,
+        command: CompletionCommands,
+    },
+    /// Manage git worktree-backed workspaces via the CLI
+    #[command(alias = "worktree")]
+    Workspace {
+        #[command(subcommand)]
+        command: WorkspaceCommands,
     },
     /// Launch the experimental desktop GUI
     Gui,
 }
 
 #[derive(Subcommand, Debug)]
-enum WorktreeCommands {
-    /// List discovered worktrees
-    List,
-    /// Add a new worktree for the specified branch
-    Add {
-        /// Branch name to create for the worktree
-        branch: String,
+enum WorkspaceCommands {
+    /// List discovered workspaces
+    List {
+        /// Emit JSON instead of a human readable table
+        #[arg(long)]
+        json: bool,
     },
-    /// Remove an existing worktree by its path
-    Remove {
-        /// Path to the worktree to remove
-        path: PathBuf,
+    /// Create a new workspace with a freshly created branch
+    Create {
+        /// Name of the branch to create for this workspace
+        branch: String,
+        /// Optional upstream reference used as the starting point
+        #[arg(long = "from", value_name = "UPSTREAM")]
+        upstream: Option<String>,
+        /// Optional path where the workspace should be created (relative paths are resolved under `.wtm/workspaces`)
+        #[arg(long, value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Emit JSON describing the created workspace
+        #[arg(long)]
+        json: bool,
+    },
+    /// Attach a workspace to an existing branch without creating a new one
+    Attach {
+        /// Name of the branch to attach
+        branch: String,
+        /// Optional path where the workspace should be created (relative paths are resolved under `.wtm/workspaces`)
+        #[arg(long, value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Emit JSON describing the attached workspace
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete an existing workspace by path, branch or name
+    #[command(alias = "remove")]
+    Delete {
+        #[command(flatten)]
+        selector: WorkspaceSelector,
         /// Force removal even if there are unmerged changes
         #[arg(long)]
         force: bool,
+        /// Emit JSON describing the removed workspace
+        #[arg(long)]
+        json: bool,
+    },
+    /// Move or rename an existing workspace to a new path
+    #[command(alias = "rename")]
+    Move {
+        #[command(flatten)]
+        selector: WorkspaceSelector,
+        /// Destination path for the workspace (relative paths are resolved under `.wtm/workspaces`)
+        #[arg(long, value_name = "PATH")]
+        to: PathBuf,
+        /// Force the move even if git detects a potential issue
+        #[arg(long)]
+        force: bool,
+        /// Emit JSON describing the moved workspace
+        #[arg(long)]
+        json: bool,
+    },
+    /// Gather telemetry information about one or more workspaces
+    Telemetry {
+        #[command(flatten)]
+        selector: WorkspaceSelector,
+        /// Emit telemetry as JSON
+        #[arg(long)]
+        json: bool,
+        /// Skip git status collection
+        #[arg(long = "no-status", action = ArgAction::SetFalse, default_value_t = true)]
+        include_status: bool,
+        /// Skip disk usage calculation
+        #[arg(long = "no-size", action = ArgAction::SetFalse, default_value_t = true)]
+        include_disk_usage: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum CompletionCommands {
+    /// Generate shell completion scripts
+    Generate {
+        #[arg(value_enum)]
+        shell: CompletionShell,
+    },
+    /// Provide dynamic suggestions for shell completion integrations
+    Suggest {
+        #[arg(value_enum)]
+        domain: SuggestionDomain,
+        /// Filter suggestions by a case-insensitive query
+        #[arg(long, value_name = "QUERY")]
+        contains: Option<String>,
+        /// Format suggestions for shell integration
+        #[arg(long, value_enum)]
+        shell: Option<SuggestionShellFormat>,
+        /// Emit JSON instead of plain text
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -69,7 +162,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Some(Commands::Init { path }) => init_command(&path),
-        Some(Commands::Worktree { command }) => run_worktree_cli(command),
+        Some(Commands::Completions { command }) => run_completions_cli(command),
+        Some(Commands::Workspace { command }) => run_workspace_cli(command),
         Some(Commands::Gui) => run_gui_frontend(),
         None => run_dashboard(),
     }
@@ -105,7 +199,7 @@ fn load_workspace_context() -> Result<WorkspaceContext> {
     let worktrees = list_worktrees(&repo_root)?;
     if worktrees.is_empty() {
         bail!(
-            "No git worktrees found for {}. Use `wtm worktree add` to create one.",
+            "No git worktrees found for {}. Use `wtm workspace create` to create one.",
             repo_root.display()
         );
     }
@@ -128,55 +222,210 @@ fn load_workspace_context() -> Result<WorkspaceContext> {
     })
 }
 
-fn run_worktree_cli(command: WorktreeCommands) -> Result<()> {
+fn run_workspace_cli(command: WorkspaceCommands) -> Result<()> {
     let cwd = std::env::current_dir().context("unable to determine current directory")?;
     let repo_root = find_repo_root(&cwd)?;
     match command {
-        WorktreeCommands::List => {
-            let worktrees = list_worktrees(&repo_root)?;
-            for wt in worktrees {
-                let mut columns = vec![wt.path.display().to_string()];
-                if let Some(branch) = wt.branch.as_deref() {
-                    columns.push(format!("branch: {branch}"));
-                }
-                if let Some(head) = wt.head.as_deref() {
-                    columns.push(format!("HEAD: {}", &head[..std::cmp::min(7, head.len())]));
-                }
-                if wt.is_locked {
-                    columns.push("locked".into());
-                }
-                if wt.is_prunable {
-                    columns.push("prunable".into());
-                }
-                println!("{}", columns.join(" | "));
-            }
-            Ok(())
-        }
-        WorktreeCommands::Add { branch } => {
-            let branch = sanitize_branch_name(&branch);
-            if branch.is_empty() {
-                bail!("Branch name is required.");
-            }
-            let workspace_root = ensure_workspace_root(&repo_root)?;
-            let dir_name = branch_dir_name(&branch);
-            let worktree_path = next_available_workspace_path(&workspace_root, &dir_name);
-            add_worktree(&repo_root, &worktree_path, Some(branch.as_str()))?;
-            println!(
-                "Created worktree for branch {branch} at {}",
-                worktree_path.display()
-            );
-            Ok(())
-        }
-        WorktreeCommands::Remove { path, force } => {
-            let workspace_root = ensure_workspace_root(&repo_root)?;
-            let full_path = if path.is_absolute() {
-                path
+        WorkspaceCommands::List { json } => {
+            let summaries = list_workspaces(&repo_root)?;
+            if json {
+                println!("{}", to_string_pretty(&summaries)?);
             } else {
-                workspace_root.join(path)
-            };
-            remove_worktree(&repo_root, &full_path, force)?;
-            println!("Removed worktree {}", full_path.display());
+                for summary in &summaries {
+                    print_workspace_summary(summary);
+                }
+            }
             Ok(())
         }
+        WorkspaceCommands::Create {
+            branch,
+            upstream,
+            path,
+            json,
+        } => {
+            let summary =
+                create_workspace(&repo_root, &branch, upstream.as_deref(), path.as_deref())?;
+            if json {
+                println!("{}", to_string_pretty(&summary)?);
+            } else {
+                println!(
+                    "Created workspace for branch {} at {}",
+                    summary.branch.as_deref().unwrap_or(branch.trim()),
+                    summary.path.display()
+                );
+                print_workspace_summary(&summary);
+            }
+            Ok(())
+        }
+        WorkspaceCommands::Attach { branch, path, json } => {
+            let summary = attach_workspace(&repo_root, &branch, path.as_deref())?;
+            if json {
+                println!("{}", to_string_pretty(&summary)?);
+            } else {
+                println!(
+                    "Attached workspace to branch {} at {}",
+                    branch.trim(),
+                    summary.path.display()
+                );
+                print_workspace_summary(&summary);
+            }
+            Ok(())
+        }
+        WorkspaceCommands::Delete {
+            selector,
+            force,
+            json,
+        } => {
+            let summary = delete_workspace(&repo_root, &selector, force)?;
+            if json {
+                println!("{}", to_string_pretty(&summary)?);
+            } else {
+                println!(
+                    "Removed workspace {} at {}",
+                    summary.name,
+                    summary.path.display()
+                );
+            }
+            Ok(())
+        }
+        WorkspaceCommands::Move {
+            selector,
+            to,
+            force,
+            json,
+        } => {
+            let summary = move_workspace(&repo_root, &selector, &to, force)?;
+            if json {
+                println!("{}", to_string_pretty(&summary)?);
+            } else {
+                println!(
+                    "Moved workspace {} to {}",
+                    summary.name,
+                    summary.path.display()
+                );
+                print_workspace_summary(&summary);
+            }
+            Ok(())
+        }
+        WorkspaceCommands::Telemetry {
+            selector,
+            json,
+            include_status,
+            include_disk_usage,
+        } => {
+            let telemetry = workspace_telemetry(
+                &repo_root,
+                &selector,
+                TelemetryOptions {
+                    include_status,
+                    include_disk_usage,
+                },
+            )?;
+            if json {
+                println!("{}", to_string_pretty(&telemetry)?);
+            } else {
+                for entry in &telemetry {
+                    print_workspace_telemetry(entry);
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn run_completions_cli(command: CompletionCommands) -> Result<()> {
+    match command {
+        CompletionCommands::Generate { shell } => {
+            let script = generate_shell_completion(shell)?;
+            print!("{script}");
+            Ok(())
+        }
+        CompletionCommands::Suggest {
+            domain,
+            contains,
+            shell,
+            json,
+        } => {
+            let repo_root = current_repo_root()?;
+            let suggestions = collect_suggestions(domain, &repo_root)?;
+            if json {
+                println!("{}", to_string_pretty(&suggestions)?);
+            } else {
+                for line in format_suggestions(&suggestions, contains.as_deref(), shell) {
+                    println!("{line}");
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_workspace_summary(summary: &WorkspaceSummary) {
+    let mut columns = vec![summary.name.clone(), summary.path.display().to_string()];
+    if let Some(branch) = summary.branch.as_deref() {
+        columns.push(format!("branch: {branch}"));
+    }
+    if let Some(head) = summary.head.as_deref() {
+        columns.push(format!("HEAD: {}", &head[..min(7, head.len())]));
+    }
+    if summary.is_locked {
+        columns.push("locked".into());
+    }
+    if summary.is_prunable {
+        columns.push("prunable".into());
+    }
+    println!("{}", columns.join(" | "));
+}
+
+fn print_workspace_telemetry(entry: &WorkspaceTelemetry) {
+    println!("{}", entry.summary.name);
+    println!("  Path: {}", entry.summary.path.display());
+    if let Some(branch) = entry.summary.branch.as_deref() {
+        println!("  Branch: {branch}");
+    }
+    if let Some(head) = entry.summary.head.as_deref() {
+        println!("  HEAD: {}", head);
+    }
+    println!(
+        "  Flags: {}",
+        format_flags(entry.summary.is_locked, entry.summary.is_prunable)
+    );
+    match (&entry.status, &entry.status_error) {
+        (Some(status), _) => {
+            println!(
+                "  Git status: branch={}, upstream={}, ahead={}, behind={}, staged={}, unstaged={}, untracked={}, conflicts={}",
+                status.branch.as_deref().unwrap_or("-"),
+                status.upstream.as_deref().unwrap_or("-"),
+                status.ahead,
+                status.behind,
+                status.staged,
+                status.unstaged,
+                status.untracked,
+                status.conflicts
+            );
+        }
+        (None, Some(error)) => println!("  Git status: unavailable ({error})"),
+        _ => {}
+    }
+    match (entry.disk_usage_bytes, &entry.disk_usage_error) {
+        (Some(bytes), _) => println!("  Disk usage: {bytes} bytes"),
+        (None, Some(error)) => println!("  Disk usage: unavailable ({error})"),
+        _ => {}
+    }
+    println!();
+}
+
+fn format_flags(is_locked: bool, is_prunable: bool) -> String {
+    let mut flags = Vec::new();
+    if is_locked {
+        flags.push("locked");
+    }
+    if is_prunable {
+        flags.push("prunable");
+    }
+    if flags.is_empty() {
+        "none".to_string()
+    } else {
+        flags.join(", ")
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
+use serde::Deserialize;
 use serde_json::Value;
 use std::{fs, path::Path, process::Command};
 use tempfile::TempDir;
@@ -74,12 +75,12 @@ fn running_with_empty_workspaces_errors() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
-fn worktree_list_outputs_primary() -> Result<(), Box<dyn std::error::Error>> {
+fn workspace_list_outputs_primary() -> Result<(), Box<dyn std::error::Error>> {
     let temp = TempDir::new()?;
     init_git_repo(temp.path())?;
 
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
-    cmd.current_dir(temp.path()).args(["worktree", "list"]);
+    cmd.current_dir(temp.path()).args(["workspace", "list"]);
     cmd.assert()
         .success()
         .stdout(predicate::str::contains(temp.path().to_string_lossy()));
@@ -87,7 +88,7 @@ fn worktree_list_outputs_primary() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn worktree_add_and_remove_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+fn workspace_create_and_delete_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
     let temp = TempDir::new()?;
     init_git_repo(temp.path())?;
 
@@ -99,15 +100,16 @@ fn worktree_add_and_remove_roundtrip() -> Result<(), Box<dyn std::error::Error>>
 
     let mut add = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
     add.current_dir(temp.path())
-        .args(["worktree", "add", branch_name]);
+        .args(["workspace", "create", branch_name]);
     add.assert().success();
 
     assert!(expected_dir.exists());
 
     let mut remove = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
     remove.current_dir(temp.path()).args([
-        "worktree",
-        "remove",
+        "workspace",
+        "delete",
+        "--path",
         expected_dir.file_name().unwrap().to_str().unwrap(),
         "--force",
     ]);
@@ -117,7 +119,7 @@ fn worktree_add_and_remove_roundtrip() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[test]
-fn worktree_add_sanitizes_branch_name() -> Result<(), Box<dyn std::error::Error>> {
+fn workspace_create_sanitizes_branch_name() -> Result<(), Box<dyn std::error::Error>> {
     let temp = TempDir::new()?;
     init_git_repo(temp.path())?;
 
@@ -130,7 +132,7 @@ fn worktree_add_sanitizes_branch_name() -> Result<(), Box<dyn std::error::Error>
 
     let mut add = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
     add.current_dir(temp.path())
-        .args(["worktree", "add", original_branch]);
+        .args(["workspace", "create", original_branch]);
     add.assert().success();
 
     assert!(expected_dir.exists());
@@ -145,6 +147,138 @@ fn worktree_add_sanitizes_branch_name() -> Result<(), Box<dyn std::error::Error>
     )?;
 
     Ok(())
+}
+
+#[test]
+fn workspace_telemetry_reports_status() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    init_git_repo(temp.path())?;
+
+    let branch_name = "feature/telemetry";
+    let workspace_name = branch_dir_name(branch_name);
+    let workspace_dir = temp.path().join(".wtm/workspaces").join(&workspace_name);
+
+    let mut create = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
+    create
+        .current_dir(temp.path())
+        .args(["workspace", "create", branch_name]);
+    create.assert().success();
+
+    assert!(workspace_dir.exists());
+    fs::write(workspace_dir.join("new_file.txt"), "hello telemetry")?;
+
+    let mut telemetry = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
+    telemetry.current_dir(temp.path()).args([
+        "workspace",
+        "telemetry",
+        "--path",
+        workspace_name.as_str(),
+        "--json",
+    ]);
+    let assertion = telemetry.assert().success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone())?;
+    let payload: Value = serde_json::from_str(&stdout)?;
+    let entries = payload
+        .as_array()
+        .ok_or_else(|| "expected telemetry array")?;
+    assert_eq!(entries.len(), 1);
+    let entry = &entries[0];
+
+    assert_eq!(entry["summary"]["branch"].as_str().unwrap(), branch_name);
+    assert_eq!(
+        entry["summary"]["path"].as_str().unwrap(),
+        workspace_dir.to_string_lossy().as_ref()
+    );
+    assert!(entry["status_error"].is_null());
+    assert!(entry["disk_usage_error"].is_null());
+    assert_eq!(entry["status"]["untracked"].as_u64().unwrap(), 1);
+    assert!(entry["disk_usage_bytes"].as_u64().unwrap() > 0);
+
+    Ok(())
+}
+
+#[test]
+fn completions_generate_outputs_bash_script() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    init_git_repo(temp.path())?;
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
+    cmd.current_dir(temp.path())
+        .args(["completions", "generate", "bash"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("__wtm_branch_suggestions"));
+
+    Ok(())
+}
+
+#[test]
+fn completions_suggest_branches_includes_local_and_ticket() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temp = TempDir::new()?;
+    init_git_repo(temp.path())?;
+
+    run_git(temp.path(), ["checkout", "-b", "feature/example"].as_ref())?;
+
+    let wtm_dir = temp.path().join(".wtm");
+    fs::create_dir_all(&wtm_dir)?;
+    let cache = serde_json::json!({
+        "tickets": [{
+            "key": "PROJ-7",
+            "summary": "Dynamic branch",
+        }]
+    });
+    fs::write(
+        wtm_dir.join("jira_cache.json"),
+        serde_json::to_string(&cache)?,
+    )?;
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
+    cmd.current_dir(temp.path())
+        .args(["completions", "suggest", "branches", "--json"]);
+
+    let assertion = cmd.assert().success();
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone())?;
+    let suggestions: Vec<CompletionSuggestionOutput> = serde_json::from_str(&stdout)?;
+
+    let has_local = suggestions.iter().any(|suggestion| {
+        suggestion.source.as_deref() == Some("local") && suggestion.value == "feature/example"
+    });
+    assert!(has_local, "expected local branch suggestion");
+
+    let has_ticket = suggestions.iter().any(|suggestion| {
+        suggestion.source.as_deref() == Some("ticket")
+            && suggestion
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("PROJ-7")
+    });
+    assert!(has_ticket, "expected ticket suggestion");
+
+    let mut shell_cmd = Command::new(assert_cmd::cargo::cargo_bin!("wtm"));
+    shell_cmd.current_dir(temp.path()).args([
+        "completions",
+        "suggest",
+        "branches",
+        "--shell",
+        "bash",
+    ]);
+    shell_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("feature/example"))
+        .stdout(predicate::str::contains("PROJ-7"));
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct CompletionSuggestionOutput {
+    value: String,
+    description: Option<String>,
+    source: Option<String>,
 }
 
 fn read_json(path: &Path) -> Result<Value, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary
- add a `completions` command that generates installable scripts and provides dynamic suggestion output for shells
- bundle bash and zsh completion scripts with workspace-aware flag handling and branch/ticket lookups
- extend CLI integration tests to cover completion script generation and suggestion aggregation

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_69088e5ed7c8832e8b4a9b87e1f01a8c