### PR TITLE
Add Python multi-agent workflow scaffolding for WTM

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Agent integrations for WTM."""

--- a/agents/wtm_multi_agent/README.md
+++ b/agents/wtm_multi_agent/README.md
@@ -1,0 +1,15 @@
+# WTM Multi-Agent Workflow
+
+This package adapts the OpenAI Codex multi-agent CLI template to the Worktree Manager
+(WTM) toolchain. It defines an orchestrated set of agents that collaborate to
+provision Git worktrees, hydrate Jira context, bootstrap React Native
+workspaces, and hand off execution to a coding agent.
+
+## Quick start
+
+```bash
+python -m wtm_multi_agent.cli --help
+```
+
+Configure the environment variables described in `config.py`, then launch the
+CLI to spawn an orchestrated session.

--- a/agents/wtm_multi_agent/__init__.py
+++ b/agents/wtm_multi_agent/__init__.py
@@ -1,0 +1,14 @@
+"""WTM Multi-Agent Workflow package."""
+
+from .config import WorkflowConfig, JiraConfig, ReactConfig
+from .context import JiraTicket, WorkspaceContext
+from .orchestrator import WorkflowOrchestrator
+
+__all__ = [
+    "WorkflowConfig",
+    "JiraConfig",
+    "ReactConfig",
+    "JiraTicket",
+    "WorkspaceContext",
+    "WorkflowOrchestrator",
+]

--- a/agents/wtm_multi_agent/agents/__init__.py
+++ b/agents/wtm_multi_agent/agents/__init__.py
@@ -1,0 +1,16 @@
+"""Agent implementations for the WTM multi-agent workflow."""
+
+from .base import Agent, ToolAgent
+from .coding import CodingAgent
+from .jira import JiraAgent
+from .react_env import ReactEnvironmentAgent
+from .worktree import WorktreeManagerAgent
+
+__all__ = [
+    "Agent",
+    "ToolAgent",
+    "CodingAgent",
+    "JiraAgent",
+    "ReactEnvironmentAgent",
+    "WorktreeManagerAgent",
+]

--- a/agents/wtm_multi_agent/agents/base.py
+++ b/agents/wtm_multi_agent/agents/base.py
@@ -1,0 +1,32 @@
+"""Base agent interfaces."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+from ..context import WorkspaceContext
+
+
+class Agent(ABC):
+    """A simple synchronous agent contract."""
+
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def describe(self) -> str:
+        """Return a short description of the agent."""
+
+    @abstractmethod
+    def handle(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        """Process a message and return structured output."""
+
+
+class ToolAgent(Agent):
+    """Agent that executes a single tool action."""
+
+    def handle(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        raise NotImplementedError("Tool agents must implement handle().")

--- a/agents/wtm_multi_agent/agents/coding.py
+++ b/agents/wtm_multi_agent/agents/coding.py
@@ -1,0 +1,27 @@
+"""Adapter agent for delegating to LLM-based coding assistants."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..context import WorkspaceContext
+from .base import Agent
+
+
+class CodingAgent(Agent):
+    """Produces prompts for an external coding assistant."""
+
+    def __init__(self, name: str = "coding-agent") -> None:
+        super().__init__(name=name)
+
+    def describe(self) -> str:
+        return "Forms a rich prompt for the external coding assistant."
+
+    def handle(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        goal = payload.get("goal", "Implement the requested feature")
+        prompt = (
+            f"{goal}\n\n"
+            f"Context:\n{context.to_prompt()}\n\n"
+            f"Please plan the changes, execute them, and report status."
+        )
+        return {"prompt": prompt, "assistant": payload.get("assistant", self.name)}

--- a/agents/wtm_multi_agent/agents/jira.py
+++ b/agents/wtm_multi_agent/agents/jira.py
@@ -1,0 +1,92 @@
+"""Agent responsible for fetching Jira tickets via acli."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..config import JiraConfig
+from ..context import JiraTicket, WorkspaceContext
+from ..utils import cli
+from .base import ToolAgent
+
+
+class JiraAgent(ToolAgent):
+    """Loads Jira context and converts it into prompt-friendly structures."""
+
+    def __init__(self, config: JiraConfig) -> None:
+        super().__init__(name="jira-context")
+        self.config = config
+
+    def describe(self) -> str:
+        return "Fetches assigned Jira tickets and caches them locally."
+
+    def handle(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        action = payload.get("action", "suggest")
+        if action == "suggest":
+            tickets = self._fetch()
+            return {"tickets": [ticket.__dict__ for ticket in tickets]}
+        if action == "detail":
+            key = payload["key"]
+            return {"ticket": self._fetch_ticket(key).__dict__}
+        raise ValueError(f"Unsupported Jira action: {action}")
+
+    def _cache_path(self) -> Path:
+        return self.config.cache_path
+
+    def _fetch(self) -> List[JiraTicket]:
+        cache_path = self._cache_path()
+        if cache_path.exists():
+            try:
+                with cache_path.open("r", encoding="utf-8") as handle:
+                    cached = json.load(handle)
+                return [self._ticket_from_json(item) for item in cached]
+            except Exception:
+                cache_path.unlink(missing_ok=True)
+        command = [
+            "acli",
+            "jira",
+            "issue",
+            "list",
+            f"--site={self.config.site}",
+            f"--user={self.config.email}",
+            f"--token={self.config.api_token}",
+            f"--limit={self.config.max_results}",
+            "--json",
+        ]
+        data = cli.run_json(command) or []
+        tickets = [self._ticket_from_json(item) for item in data]
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with cache_path.open("w", encoding="utf-8") as handle:
+            json.dump([ticket.__dict__ for ticket in tickets], handle, indent=2)
+        return tickets
+
+    def _fetch_ticket(self, key: str) -> JiraTicket:
+        command = [
+            "acli",
+            "jira",
+            "issue",
+            "get",
+            key,
+            f"--site={self.config.site}",
+            f"--user={self.config.email}",
+            f"--token={self.config.api_token}",
+            "--json",
+        ]
+        data = cli.run_json(command) or {}
+        return self._ticket_from_json(data)
+
+    @staticmethod
+    def _ticket_from_json(data: Dict[str, Any]) -> JiraTicket:
+        fields = data.get("fields", {})
+        return JiraTicket(
+            key=data.get("key", ""),
+            summary=fields.get("summary", ""),
+            url=data.get("self"),
+            labels=fields.get("labels", []),
+            extra={
+                "status": fields.get("status", {}).get("name", ""),
+                "assignee": (fields.get("assignee") or {}).get("displayName", ""),
+            },
+        )

--- a/agents/wtm_multi_agent/agents/react_env.py
+++ b/agents/wtm_multi_agent/agents/react_env.py
@@ -1,0 +1,30 @@
+"""Agent that prepares quick actions for React Native workspaces."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..config import ReactConfig
+from ..context import WorkspaceContext
+from .base import ToolAgent
+
+
+class ReactEnvironmentAgent(ToolAgent):
+    """Enriches workspace context with React-specific quick actions."""
+
+    def __init__(self, config: ReactConfig) -> None:
+        super().__init__(name="react-environment")
+        self.config = config
+
+    def describe(self) -> str:
+        return "Adds React Native quick actions and environment hints to the workspace."
+
+    def handle(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        extra_actions = payload.get("extra_actions", [])
+        merged_actions = list(dict.fromkeys([*self.config.quick_actions, *extra_actions]))
+        context.quick_actions[:] = merged_actions
+        context.env.update(self.config.extra_env)
+        return {
+            "quick_actions": merged_actions,
+            "env": context.env,
+        }

--- a/agents/wtm_multi_agent/agents/worktree.py
+++ b/agents/wtm_multi_agent/agents/worktree.py
@@ -1,0 +1,64 @@
+"""Agent responsible for creating and cleaning up worktrees via WTM."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..config import WorkflowConfig
+from ..context import WorkspaceContext
+from ..utils import cli
+from .base import ToolAgent
+
+
+@dataclass
+class WorktreeManagerAgent(ToolAgent):
+    """Wraps `wtm worktree` commands."""
+
+    config: WorkflowConfig
+
+    def __init__(self, config: WorkflowConfig) -> None:
+        super().__init__(name="worktree-manager")
+        self.config = config
+
+    def describe(self) -> str:
+        return "Creates, lists, and prunes WTM-managed worktrees."
+
+    def handle(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        action = payload.get("action")
+        if action == "add":
+            return self._add(payload, context)
+        if action == "remove":
+            return self._remove(payload, context)
+        if action == "list":
+            return self._list(payload)
+        raise ValueError(f"Unsupported worktree action: {action}")
+
+    def _add(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        branch = payload.get("branch") or context.ticket.slug
+        path_hint: Optional[str] = payload.get("path")
+        args = [self.config.wtm_binary, "worktree", "add", branch]
+        if path_hint:
+            args.append(path_hint)
+        cli.run(args, cwd=self.config.repo_root)
+        worktrees = self._list({})["worktrees"]
+        worktree_path = next((Path(item["path"]) for item in worktrees if item["branch"] == branch), None)
+        return {
+            "branch": branch,
+            "path": str(worktree_path) if worktree_path else None,
+        }
+
+    def _remove(self, payload: Dict[str, Any], context: WorkspaceContext) -> Dict[str, Any]:
+        branch = payload.get("branch") or context.ticket.slug
+        force = payload.get("force", False)
+        args = [self.config.wtm_binary, "worktree", "remove", branch]
+        if force:
+            args.append("--force")
+        cli.run(args, cwd=self.config.repo_root)
+        return {"branch": branch, "removed": True}
+
+    def _list(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        args = [self.config.wtm_binary, "worktree", "list", "--json"]
+        result = cli.run_json(args, cwd=self.config.repo_root)
+        return {"worktrees": result or []}

--- a/agents/wtm_multi_agent/cli.py
+++ b/agents/wtm_multi_agent/cli.py
@@ -1,0 +1,65 @@
+"""Command-line interface for the WTM multi-agent workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .config import JiraConfig, WorkflowConfig
+from .context import JiraTicket
+from .orchestrator import WorkflowOrchestrator
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the WTM multi-agent workflow.")
+    parser.add_argument("ticket", help="Jira ticket key (e.g., MOB-123)")
+    parser.add_argument("summary", help="Short summary of the ticket")
+    parser.add_argument("repo", type=Path, help="Path to the Git repository root")
+    parser.add_argument("--wtm", dest="wtm_binary", default="wtm", help="Path to the WTM binary")
+    parser.add_argument("--assistant", default="claude", help="Coding assistant identifier")
+    parser.add_argument("--jira-site", dest="jira_site", help="Jira site identifier for acli")
+    parser.add_argument("--jira-email", dest="jira_email", help="Email used for Jira authentication")
+    parser.add_argument("--jira-token", dest="jira_token", help="API token used for Jira authentication")
+    parser.add_argument(
+        "--extra-action",
+        dest="extra_actions",
+        action="append",
+        default=[],
+        help="Additional quick action command to enqueue",
+    )
+    parser.add_argument("--json", action="store_true", help="Return output as JSON")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    jira_config = None
+    if args.jira_site and args.jira_email and args.jira_token:
+        jira_config = JiraConfig(site=args.jira_site, email=args.jira_email, api_token=args.jira_token)
+
+    workflow_config = WorkflowConfig(
+        repo_root=args.repo.resolve(),
+        wtm_binary=args.wtm_binary,
+        coding_agent=args.assistant,
+        jira=jira_config,
+    )
+
+    orchestrator = WorkflowOrchestrator(workflow_config)
+    ticket = JiraTicket(key=args.ticket, summary=args.summary)
+    context = orchestrator.initialise_workspace(ticket)
+    if args.extra_actions:
+        orchestrator.update_quick_actions(args.extra_actions, context)
+    plan = orchestrator.plan(ticket)
+
+    if args.json:
+        print(json.dumps({"prompt": plan["prompt"], "assistant": plan["assistant"]}, indent=2))
+    else:
+        print(f"Assistant: {plan['assistant']}")
+        print("Prompt:\n")
+        print(plan["prompt"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/agents/wtm_multi_agent/config.py
+++ b/agents/wtm_multi_agent/config.py
@@ -1,0 +1,51 @@
+"""Configuration dataclasses for the workflow orchestrator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class JiraConfig:
+    """Settings required to query Jira via the Atlassian CLI."""
+
+    site: str
+    email: str
+    api_token: str
+    cache_path: Path = Path(".wtm/jira_cache.json")
+    max_results: int = 10
+
+
+@dataclass
+class ReactConfig:
+    """Commands and settings for React Native quick actions."""
+
+    quick_actions: List[str] = field(
+        default_factory=lambda: [
+            "npm install",
+            "npm run lint",
+            "npm run test",
+            "npx expo start --dev-client",
+        ]
+    )
+    extra_env: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class WorkflowConfig:
+    """Top-level configuration for orchestrator and agents."""
+
+    repo_root: Path
+    openai_model: str = "gpt-4.1"
+    wtm_binary: str = "wtm"
+    coding_agent: str = "claude"
+    jira: Optional[JiraConfig] = None
+    react: ReactConfig = field(default_factory=ReactConfig)
+
+    def ensure_paths(self) -> None:
+        """Make sure cache directories exist."""
+
+        if self.jira:
+            self.jira.cache_path.parent.mkdir(parents=True, exist_ok=True)

--- a/agents/wtm_multi_agent/context.py
+++ b/agents/wtm_multi_agent/context.py
@@ -1,0 +1,50 @@
+"""Shared context objects used by multiple agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class JiraTicket:
+    """Represents the subset of Jira ticket data we care about."""
+
+    key: str
+    summary: str
+    url: Optional[str] = None
+    labels: List[str] = field(default_factory=list)
+    extra: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def slug(self) -> str:
+        """Return a filesystem-friendly slug suitable for branch names."""
+
+        normalised = self.summary.lower().replace(" ", "-")
+        safe = "".join(ch for ch in normalised if ch.isalnum() or ch in {"-", "_"})
+        return f"{self.key.lower()}-{safe}"[:80]
+
+
+@dataclass
+class WorkspaceContext:
+    """Aggregated view of the active worktree workspace."""
+
+    repo_root: Path
+    worktree_path: Path
+    ticket: JiraTicket
+    quick_actions: List[str]
+    env: Dict[str, str] = field(default_factory=dict)
+
+    def to_prompt(self) -> str:
+        """Render a human-readable summary for coding agents."""
+
+        actions = "\n".join(f"- {action}" for action in self.quick_actions)
+        env_lines = "\n".join(f"{key}={value}" for key, value in sorted(self.env.items()))
+        return (
+            f"Repository root: {self.repo_root}\n"
+            f"Worktree path: {self.worktree_path}\n"
+            f"Ticket: {self.ticket.key} — {self.ticket.summary}\n"
+            f"Quick actions:\n{actions or '  (none)'}\n"
+            f"Environment:\n{env_lines or '  (none)'}"
+        )

--- a/agents/wtm_multi_agent/orchestrator.py
+++ b/agents/wtm_multi_agent/orchestrator.py
@@ -1,0 +1,108 @@
+"""Workflow orchestrator that wires the individual agents together."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .agents.base import Agent
+from .agents.coding import CodingAgent
+from .agents.jira import JiraAgent
+from .agents.react_env import ReactEnvironmentAgent
+from .agents.worktree import WorktreeManagerAgent
+from .config import JiraConfig, WorkflowConfig
+from .context import JiraTicket, WorkspaceContext
+
+
+@dataclass
+class WorkflowOrchestrator:
+    """Coordinates the multi-agent workflow for WTM tasks."""
+
+    config: WorkflowConfig
+    agents: List[Agent] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.config.ensure_paths()
+        if not self.agents:
+            self.agents = self._default_agents()
+
+    def _default_agents(self) -> List[Agent]:
+        agents: List[Agent] = [
+            WorktreeManagerAgent(self.config),
+            ReactEnvironmentAgent(self.config.react),
+            CodingAgent(self.config.coding_agent),
+        ]
+        if isinstance(self.config.jira, JiraConfig):
+            agents.insert(0, JiraAgent(self.config.jira))
+        return agents
+
+    def initialise_workspace(self, ticket: JiraTicket) -> WorkspaceContext:
+        """Create a WorkspaceContext and ensure quick actions are loaded."""
+
+        worktree_dir = self.config.repo_root / ".wtm" / "workspaces" / ticket.slug
+        context = WorkspaceContext(
+            repo_root=self.config.repo_root,
+            worktree_path=worktree_dir,
+            ticket=ticket,
+            quick_actions=list(self.config.react.quick_actions),
+            env=dict(self.config.react.extra_env),
+        )
+        for agent in self.agents:
+            if isinstance(agent, ReactEnvironmentAgent):
+                agent.handle({}, context)
+        return context
+
+    def plan(self, ticket: JiraTicket) -> Dict[str, str]:
+        """Produce a plan that the coding agent can execute."""
+
+        context = self.initialise_workspace(ticket)
+        worktree_agent = self._agent_of_type(WorktreeManagerAgent)
+        if worktree_agent:
+            worktree_agent.handle({"action": "add", "branch": ticket.slug}, context)
+        coding_agent = self._agent_of_type(CodingAgent)
+        if not coding_agent:
+            raise RuntimeError("Coding agent is not configured")
+        prompt_payload = coding_agent.handle(
+            {
+                "goal": f"Implement Jira ticket {ticket.key}",
+                "assistant": self.config.coding_agent,
+            },
+            context,
+        )
+        return {"prompt": prompt_payload["prompt"], "assistant": prompt_payload["assistant"]}
+
+    def update_quick_actions(self, actions: List[str], context: Optional[WorkspaceContext] = None) -> None:
+        """Push additional quick actions into the context and agents."""
+
+        if context is None:
+            raise ValueError("Workspace context is required")
+        react_agent = self._agent_of_type(ReactEnvironmentAgent)
+        if react_agent:
+            react_agent.handle({"extra_actions": actions}, context)
+
+    def _agent_of_type(self, agent_type):
+        for agent in self.agents:
+            if isinstance(agent, agent_type):
+                return agent
+        return None
+
+    def describe_agents(self) -> Dict[str, str]:
+        """Return a mapping of agent names to descriptions."""
+
+        return {agent.name: agent.describe() for agent in self.agents}
+
+    def fetch_ticket_suggestions(self) -> List[Dict[str, str]]:
+        """Retrieve Jira suggestions if the Jira agent is configured."""
+
+        jira_agent = self._agent_of_type(JiraAgent)
+        if not jira_agent:
+            return []
+        context = WorkspaceContext(
+            repo_root=self.config.repo_root,
+            worktree_path=self.config.repo_root,
+            ticket=JiraTicket(key="", summary=""),
+            quick_actions=[],
+        )
+        result = jira_agent.handle({"action": "suggest"}, context)
+        return result.get("tickets", [])

--- a/agents/wtm_multi_agent/utils/__init__.py
+++ b/agents/wtm_multi_agent/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the WTM multi-agent workflow."""
+
+from . import cli
+
+__all__ = ["cli"]

--- a/agents/wtm_multi_agent/utils/cli.py
+++ b/agents/wtm_multi_agent/utils/cli.py
@@ -1,0 +1,47 @@
+"""Helper utilities for calling external CLIs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
+
+
+class CLIError(RuntimeError):
+    """Exception raised when a subprocess exits with a non-zero code."""
+
+    def __init__(self, command: Iterable[str], exit_code: int, stdout: str, stderr: str) -> None:
+        self.command = list(command)
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        message = "Command failed" if exit_code else "Command succeeded"
+        super().__init__(
+            f"{message}: {' '.join(self.command)} (exit code {exit_code})\n"
+            f"stdout:\n{stdout}\n"
+            f"stderr:\n{stderr}"
+        )
+
+
+def run(command: Iterable[str], cwd: Optional[Path] = None, env: Optional[Mapping[str, str]] = None) -> str:
+    """Execute a command and return stdout, raising on failure."""
+
+    result = subprocess.run(
+        list(command),
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise CLIError(command, result.returncode, result.stdout, result.stderr)
+    return result.stdout.strip()
+
+
+def run_json(command: Iterable[str], cwd: Optional[Path] = None, env: Optional[Mapping[str, str]] = None):
+    """Execute a command and parse JSON from stdout."""
+
+    output = run(command, cwd=cwd, env=env)
+    return json.loads(output) if output else None


### PR DESCRIPTION
## Summary
- add a Python `wtm_multi_agent` package that adapts the Codex CLI template to the WTM workflow
- implement agents for Jira context, worktree management, React environment setup, and coding hand-off
- provide an orchestrator and CLI entry point for generating coding prompts per Jira ticket

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6909d3d540c0832e957108f07fb080a4